### PR TITLE
update: renamed XioConn to Conn and XioConnCfg to ConnCfg

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Takayuki Sato. All Rights Reserved.
+// This program is free software under MIT License.
+// See the file LICENSE in this distribution for more details.
+
+package sabi
+
+import (
+	"sync"
+)
+
+// Conn is an interface which represents a connection to an external data
+// source and requires a methods: #Commit, #Roolback and #Close to work in a
+// transaction process.
+type Conn interface {
+	Commit() Err
+	Rollback()
+	Close()
+}
+
+// ConnCfg is an interface which requires a method: #CreateConn which creates
+// a connection to a data source with configuration parameters.
+type ConnCfg interface {
+	CreateConn() (Conn, Err)
+}
+
+var (
+	isGlobalConnCfgSealed bool               = false
+	globalConnCfgMap      map[string]ConnCfg = make(map[string]ConnCfg)
+	globalConnCfgMutex    sync.Mutex
+)
+
+// AddGlobalConnCfg registers a global ConnCfg with its name to make enable
+// to use ConnCfg in all processes..
+func AddGlobalConnCfg(name string, cfg ConnCfg) {
+	globalConnCfgMutex.Lock()
+	defer globalConnCfgMutex.Unlock()
+
+	if !isGlobalConnCfgSealed {
+		globalConnCfgMap[name] = cfg
+	}
+}
+
+// SealGlobalConnCfgs makes unable to register any further global ConnCfg.
+func SealGlobalConnCfgs() {
+	isGlobalConnCfgSealed = true
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,125 @@
+package sabi
+
+import (
+	"container/list"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var logs list.List
+var willFailToCreateFooConn bool = false
+var willFailToCommitFooConn bool = false
+
+type /* error reason */ (
+	InvalidConn struct{}
+)
+
+func Clear() {
+	isGlobalConnCfgSealed = false
+	globalConnCfgMap = make(map[string]ConnCfg)
+
+	logs.Init()
+
+	willFailToCreateFooConn = false
+	willFailToCommitFooConn = false
+}
+
+type FooConn struct {
+	Label string
+}
+
+func (conn *FooConn) Commit() Err {
+	if willFailToCommitFooConn {
+		return ErrBy(InvalidConn{})
+	}
+	logs.PushBack("FooConn#Commit")
+	return Ok()
+}
+func (conn *FooConn) Rollback() {
+	logs.PushBack("FooConn#Rollback")
+}
+func (conn *FooConn) Close() {
+	logs.PushBack("FooConn#Close")
+}
+
+type FooConnCfg struct {
+	Label string
+}
+
+func (cfg FooConnCfg) CreateConn() (Conn, Err) {
+	if willFailToCreateFooConn {
+		return nil, ErrBy(InvalidConn{})
+	}
+	return &FooConn{Label: cfg.Label}, Ok()
+}
+
+type BarConn struct {
+	Label string
+}
+
+func (conn *BarConn) Commit() Err {
+	logs.PushBack("BarConn#Commit")
+	return Ok()
+}
+func (conn *BarConn) Rollback() {
+	logs.PushBack("BarConn#Rollback")
+}
+func (conn *BarConn) Close() {
+	logs.PushBack("BarConn#Close")
+}
+
+type BarConnCfg struct {
+	Label string
+}
+
+func (cfg BarConnCfg) CreateConn() (Conn, Err) {
+	return &BarConn{Label: cfg.Label}, Ok()
+}
+
+func TestAddGlobalConnCfg(t *testing.T) {
+	Clear()
+	defer Clear()
+
+	assert.False(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 0)
+
+	AddGlobalConnCfg("foo", FooConnCfg{})
+
+	assert.False(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 1)
+
+	AddGlobalConnCfg("bar", &BarConnCfg{})
+
+	assert.False(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 2)
+}
+
+func TestSealGlobalConnCfgs(t *testing.T) {
+	Clear()
+	defer Clear()
+
+	assert.False(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 0)
+
+	AddGlobalConnCfg("foo", FooConnCfg{})
+
+	assert.False(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 1)
+
+	SealGlobalConnCfgs()
+
+	assert.True(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 1)
+
+	AddGlobalConnCfg("foo", FooConnCfg{})
+
+	assert.True(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 1)
+
+	isGlobalConnCfgSealed = false
+
+	AddGlobalConnCfg("bar", &BarConnCfg{})
+
+	assert.False(t, isGlobalConnCfgSealed)
+	assert.Equal(t, len(globalConnCfgMap), 2)
+}

--- a/xio_test.go
+++ b/xio_test.go
@@ -1,66 +1,10 @@
 package sabi
 
 import (
-	"container/list"
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
-
-var logs list.List
-
-var willFooConnFailToCommit bool = false
-var willFooConnFailToRollback bool = false
-var willFooConnFailToClose bool = false
-
-func ClearGlobalXioConnCfgs() {
-	isGlobalXioConnCfgSealed = false
-	globalXioConnCfgMap = make(map[string]XioConnCfg)
-
-	logs.Init()
-
-	willFooConnFailToCommit = false
-	willFooConnFailToRollback = false
-	willFooConnFailToClose = false
-}
-
-type /* error reasons */ (
-	InvalidXioConn struct{}
-
-	FooConnFailedToCommit   struct{}
-	FooConnFailedToRollback struct{}
-	FooConnFailedToClose    struct{}
-)
-
-var willFailToCreateXioConn bool = false
-
-type FooXioConn struct {
-	Label string
-}
-
-func (conn *FooXioConn) Commit() Err {
-	if willFooConnFailToCommit {
-		return ErrBy(FooConnFailedToCommit{})
-	}
-	logs.PushBack("FooXioConn#Commit")
-	return Ok()
-}
-
-func (conn *FooXioConn) Rollback() Err {
-	if willFooConnFailToRollback {
-		return ErrBy(FooConnFailedToRollback{})
-	}
-	logs.PushBack("FooXioConn#Rollback")
-	return Ok()
-}
-
-func (conn *FooXioConn) Close() Err {
-	if willFooConnFailToClose {
-		return ErrBy(FooConnFailedToClose{})
-	}
-	logs.PushBack("FooXioConn#Close")
-	return Ok()
-}
 
 type FooXio struct {
 	Xio
@@ -70,41 +14,12 @@ func NewFooXio(xio Xio) FooXio {
 	return FooXio{Xio: xio}
 }
 
-func (xio FooXio) GetFooConn(name string) (*FooXioConn, Err) {
+func (xio FooXio) GetFooConn(name string) (*FooConn, Err) {
 	conn, err := xio.GetConn(name)
 	if !err.IsOk() {
 		return nil, err
 	}
-	return conn.(*FooXioConn), Ok()
-}
-
-type FooXioConnCfg struct {
-	Label string
-}
-
-func (cfg FooXioConnCfg) NewConn() (XioConn, Err) {
-	if willFailToCreateXioConn {
-		return nil, ErrBy(InvalidXioConn{})
-	}
-	return &FooXioConn{Label: cfg.Label}, Ok()
-}
-
-type BarXioConn struct {
-}
-
-func (conn *BarXioConn) Commit() Err {
-	logs.PushBack("BarXioConn#Commit")
-	return Ok()
-}
-
-func (conn *BarXioConn) Rollback() Err {
-	logs.PushBack("BarXioConn#Rollback")
-	return Ok()
-}
-
-func (conn *BarXioConn) Close() Err {
-	logs.PushBack("BarXioConn#Close")
-	return Ok()
+	return conn.(*FooConn), Ok()
 }
 
 type BarXio struct {
@@ -115,175 +30,119 @@ func NewBarXio(xio Xio) BarXio {
 	return BarXio{Xio: xio}
 }
 
-func (xio BarXio) GetBarConn(name string) (*BarXioConn, Err) {
+func (xio BarXio) GetBarConn(name string) (*BarConn, Err) {
 	conn, err := xio.GetConn(name)
 	if !err.IsOk() {
 		return nil, err
 	}
-	return conn.(*BarXioConn), Ok()
-}
-
-type BarXioConnCfg struct {
-	Label string
-}
-
-func (cfg *BarXioConnCfg) NewConn() (XioConn, Err) {
-	return &BarXioConn{}, Ok()
-}
-
-func TestAddGlobalXioConnCfg(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
-
-	assert.False(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 0)
-
-	AddGlobalXioConnCfg("foo", FooXioConnCfg{})
-
-	assert.False(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 1)
-
-	AddGlobalXioConnCfg("bar", &BarXioConnCfg{})
-
-	assert.False(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 2)
-}
-
-func TestSealGlobalXioConnCfgs(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
-
-	assert.False(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 0)
-
-	AddGlobalXioConnCfg("foo", FooXioConnCfg{})
-
-	assert.False(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 1)
-
-	SealGlobalXioConnCfgs()
-
-	assert.True(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 1)
-
-	AddGlobalXioConnCfg("foo", FooXioConnCfg{})
-
-	assert.True(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 1)
-
-	isGlobalXioConnCfgSealed = false
-
-	AddGlobalXioConnCfg("bar", &BarXioConnCfg{})
-
-	assert.False(t, isGlobalXioConnCfgSealed)
-	assert.Equal(t, len(globalXioConnCfgMap), 2)
+	return conn.(*BarConn), Ok()
 }
 
 func TestNewXioBase(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 0)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 0)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 }
 
-func TestXioBase_AddLocalXioConnCfg(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+func TestXioBase_AddLocalConnCfg(t *testing.T) {
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 0)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 0)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 
-	base.AddLocalXioConnCfg("foo-local", FooXioConnCfg{})
+	base.AddLocalConnCfg("foo-local", FooConnCfg{})
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 1)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 1)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 
-	base.AddLocalXioConnCfg("bar-local", &BarXioConnCfg{})
+	base.AddLocalConnCfg("bar-local", &BarConnCfg{})
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 2)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 2)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 }
 
-func TestXioBase_SealLocalXioConnCfg(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+func TestXioBase_SealLocalConnCfg(t *testing.T) {
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 0)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 0)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 
-	base.AddLocalXioConnCfg("foo-local", FooXioConnCfg{})
+	base.AddLocalConnCfg("foo-local", FooConnCfg{})
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 1)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 1)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 
-	base.SealLocalXioConnCfgs()
+	base.SealLocalConnCfgs()
 
-	assert.True(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 1)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.True(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 1)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 
-	base.AddLocalXioConnCfg("bar-local", &BarXioConnCfg{})
+	base.AddLocalConnCfg("bar-local", &BarConnCfg{})
 
-	assert.True(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 1)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.True(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 1)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 
-	base.isLocalXioConnCfgSealed = false
+	base.isLocalConnCfgSealed = false
 
-	base.AddLocalXioConnCfg("bar-local", &BarXioConnCfg{})
+	base.AddLocalConnCfg("bar-local", &BarConnCfg{})
 
-	assert.False(t, base.isLocalXioConnCfgSealed)
-	assert.Equal(t, len(base.localXioConnCfgMap), 2)
-	assert.Equal(t, len(base.xioConnMap), 0)
+	assert.False(t, base.isLocalConnCfgSealed)
+	assert.Equal(t, len(base.localConnCfgMap), 2)
+	assert.Equal(t, len(base.connMap), 0)
 	assert.Equal(t, len(base.innerMap), 0)
 	assert.True(t, base.error.IsOk())
 }
 
-func TestXioBase_GetConn_withLocalXioConnCfg(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+func TestXioBase_GetConn_withLocalConnCfg(t *testing.T) {
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
 	conn0, err0 := base.GetConn("foo")
 	assert.Nil(t, conn0)
 	switch err0.Reason().(type) {
-	case XioConnCfgIsNotFound:
+	case ConnCfgIsNotFound:
 		assert.Equal(t, err0.Get("Name"), "foo")
 	default:
 		assert.Fail(t, err0.Error())
 	}
 
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
 
 	conn1, err1 := base.GetConn("foo")
 	assert.NotNil(t, conn1)
@@ -294,23 +153,23 @@ func TestXioBase_GetConn_withLocalXioConnCfg(t *testing.T) {
 	assert.True(t, err2.IsOk())
 }
 
-func TestXioBase_GetConn_withGlobalXioConnCfg(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+func TestXioBase_GetConn_withGlobalConnCfg(t *testing.T) {
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
 	conn0, err0 := base.GetConn("foo")
 	assert.Nil(t, conn0)
 	switch err0.Reason().(type) {
-	case XioConnCfgIsNotFound:
+	case ConnCfgIsNotFound:
 		assert.Equal(t, err0.Get("Name"), "foo")
 	default:
 		assert.Fail(t, err0.Error())
 	}
 
-	AddGlobalXioConnCfg("foo", FooXioConnCfg{})
-	SealGlobalXioConnCfgs()
+	AddGlobalConnCfg("foo", FooConnCfg{})
+	SealGlobalConnCfgs()
 
 	conn1, err1 := base.GetConn("foo")
 	assert.NotNil(t, conn1)
@@ -322,47 +181,47 @@ func TestXioBase_GetConn_withGlobalXioConnCfg(t *testing.T) {
 }
 
 func TestXioBase_GetConn_localCfgIsTakenPriorityOfGlobalCfg(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
 	conn, err := base.GetConn("foo")
 	assert.Nil(t, conn)
 	switch err.Reason().(type) {
-	case XioConnCfgIsNotFound:
+	case ConnCfgIsNotFound:
 		assert.Equal(t, err.Get("Name"), "foo")
 	default:
 		assert.Fail(t, err.Error())
 	}
 
-	AddGlobalXioConnCfg("foo", FooXioConnCfg{Label: "global"})
-	SealGlobalXioConnCfgs()
+	AddGlobalConnCfg("foo", FooConnCfg{Label: "global"})
+	SealGlobalConnCfgs()
 
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{Label: "local"})
+	base.AddLocalConnCfg("foo", FooConnCfg{Label: "local"})
 
 	conn, err = base.GetConn("foo")
-	assert.Equal(t, conn.(*FooXioConn).Label, "local")
+	assert.Equal(t, conn.(*FooConn).Label, "local")
 	assert.True(t, err.IsOk())
 }
 
 func TestXioBase_GetConn_failToCreateConn(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
-	willFailToCreateXioConn = true
-	defer func() { willFailToCreateXioConn = false }()
+	willFailToCreateFooConn = true
+	defer func() { willFailToCreateFooConn = false }()
 
 	base := NewXioBase()
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
+	base.AddLocalConnCfg("foo", FooConnCfg{})
 
 	conn, err := base.GetConn("foo")
 	assert.Nil(t, conn)
 	switch err.Reason().(type) {
-	case FailToCreateXioConn:
+	case FailToCreateConn:
 		assert.Equal(t, err.Get("Name"), "foo")
 		switch err.Cause().(Err).Reason().(type) {
-		case InvalidXioConn:
+		case InvalidConn:
 		default:
 			assert.Fail(t, err.Error())
 		}
@@ -372,28 +231,28 @@ func TestXioBase_GetConn_failToCreateConn(t *testing.T) {
 }
 
 func TestXioBase_GetConn_ForEachDataSrc(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
+	base.SealLocalConnCfgs()
 
 	fooXio := NewFooXio(base)
 	fooConn, err0 := fooXio.GetFooConn("foo")
 	assert.True(t, err0.IsOk())
-	assert.Equal(t, reflect.TypeOf(fooConn).String(), "*sabi.FooXioConn")
+	assert.Equal(t, reflect.TypeOf(fooConn).String(), "*sabi.FooConn")
 
 	barXio := NewBarXio(base)
 	barConn, err1 := barXio.GetBarConn("bar")
 	assert.True(t, err1.IsOk())
-	assert.Equal(t, reflect.TypeOf(barConn).String(), "*sabi.BarXioConn")
+	assert.Equal(t, reflect.TypeOf(barConn).String(), "*sabi.BarConn")
 }
 
 func TestXioBase_InnerMap(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
@@ -410,14 +269,14 @@ func TestXioBase_InnerMap(t *testing.T) {
 }
 
 func TestXioBase_commit(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
+	base.SealLocalConnCfgs()
 
 	fooXio := NewFooXio(base)
 	fooConn, _ := fooXio.GetFooConn("foo")
@@ -431,24 +290,24 @@ func TestXioBase_commit(t *testing.T) {
 	assert.True(t, err.IsOk())
 
 	assert.Equal(t, logs.Len(), 2)
-	if logs.Front().Value == "FooXioConn#Commit" {
-		assert.Equal(t, logs.Front().Value, "FooXioConn#Commit")
-		assert.Equal(t, logs.Back().Value, "BarXioConn#Commit")
+	if logs.Front().Value == "FooConn#Commit" {
+		assert.Equal(t, logs.Front().Value, "FooConn#Commit")
+		assert.Equal(t, logs.Back().Value, "BarConn#Commit")
 	} else {
-		assert.Equal(t, logs.Front().Value, "BarXioConn#Commit")
-		assert.Equal(t, logs.Back().Value, "FooXioConn#Commit")
+		assert.Equal(t, logs.Front().Value, "BarConn#Commit")
+		assert.Equal(t, logs.Back().Value, "FooConn#Commit")
 	}
 }
 
 func TestXioBase_commit_failed(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
+	base.SealLocalConnCfgs()
 
 	fooXio := NewFooXio(base)
 	fooConn, _ := fooXio.GetFooConn("foo")
@@ -458,31 +317,31 @@ func TestXioBase_commit_failed(t *testing.T) {
 	barConn, _ := barXio.GetBarConn("bar")
 	assert.NotNil(t, barConn)
 
-	willFooConnFailToCommit = true
+	willFailToCommitFooConn = true
 
 	err := base.commit()
 	assert.False(t, err.IsOk())
 	switch err.Reason().(type) {
-	case FailToCommitXioConn:
+	case FailToCommitConn:
 		m := err.Get("Errors").(map[string]Err)
-		assert.Equal(t, m["foo"].ReasonName(), "FooConnFailedToCommit")
+		assert.Equal(t, m["foo"].ReasonName(), "InvalidConn")
 	default:
 		assert.Fail(t, err.Error())
 	}
 
 	assert.Equal(t, logs.Len(), 1)
-	assert.Equal(t, logs.Back().Value, "BarXioConn#Commit")
+	assert.Equal(t, logs.Back().Value, "BarConn#Commit")
 }
 
-func TestXioBase_rollback(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+func TestXioBase_Rollback(t *testing.T) {
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
+	base.SealLocalConnCfgs()
 
 	fooXio := NewFooXio(base)
 	fooConn, _ := fooXio.GetFooConn("foo")
@@ -492,28 +351,27 @@ func TestXioBase_rollback(t *testing.T) {
 	barConn, _ := barXio.GetBarConn("bar")
 	assert.NotNil(t, barConn)
 
-	err := base.rollback()
-	assert.True(t, err.IsOk())
+	base.rollback()
 
 	assert.Equal(t, logs.Len(), 2)
-	if logs.Front().Value == "FooXioConn#Rollback" {
-		assert.Equal(t, logs.Front().Value, "FooXioConn#Rollback")
-		assert.Equal(t, logs.Back().Value, "BarXioConn#Rollback")
+	if logs.Front().Value == "FooConn#Rollback" {
+		assert.Equal(t, logs.Front().Value, "FooConn#Rollback")
+		assert.Equal(t, logs.Back().Value, "BarConn#Rollback")
 	} else {
-		assert.Equal(t, logs.Front().Value, "BarXioConn#Rollback")
-		assert.Equal(t, logs.Back().Value, "FooXioConn#Rollback")
+		assert.Equal(t, logs.Front().Value, "BarConn#Rollback")
+		assert.Equal(t, logs.Back().Value, "FooConn#Rollback")
 	}
 }
 
-func TestXioBase_rollback_failed(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
+func TestXioBase_Close(t *testing.T) {
+	Clear()
+	defer Clear()
 
 	base := NewXioBase()
 
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
+	base.AddLocalConnCfg("foo", FooConnCfg{})
+	base.AddLocalConnCfg("bar", &BarConnCfg{})
+	base.SealLocalConnCfgs()
 
 	fooXio := NewFooXio(base)
 	fooConn, _ := fooXio.GetFooConn("foo")
@@ -523,83 +381,14 @@ func TestXioBase_rollback_failed(t *testing.T) {
 	barConn, _ := barXio.GetBarConn("bar")
 	assert.NotNil(t, barConn)
 
-	willFooConnFailToRollback = true
-
-	err := base.rollback()
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
-	case FailToRollbackXioConn:
-		m := err.Get("Errors").(map[string]Err)
-		assert.Equal(t, m["foo"].ReasonName(), "FooConnFailedToRollback")
-	default:
-		assert.Fail(t, err.Error())
-	}
-
-	assert.Equal(t, logs.Len(), 1)
-	assert.Equal(t, logs.Back().Value, "BarXioConn#Rollback")
-}
-
-func TestXioBase_close(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
-
-	base := NewXioBase()
-
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
-
-	fooXio := NewFooXio(base)
-	fooConn, _ := fooXio.GetFooConn("foo")
-	assert.NotNil(t, fooConn)
-
-	barXio := NewBarXio(base)
-	barConn, _ := barXio.GetBarConn("bar")
-	assert.NotNil(t, barConn)
-
-	err := base.close()
-	assert.True(t, err.IsOk())
+	base.close()
 
 	assert.Equal(t, logs.Len(), 2)
-	if logs.Front().Value == "FooXioConn#Close" {
-		assert.Equal(t, logs.Front().Value, "FooXioConn#Close")
-		assert.Equal(t, logs.Back().Value, "BarXioConn#Close")
+	if logs.Front().Value == "FooConn#Close" {
+		assert.Equal(t, logs.Front().Value, "FooConn#Close")
+		assert.Equal(t, logs.Back().Value, "BarConn#Close")
 	} else {
-		assert.Equal(t, logs.Front().Value, "BarXioConn#Close")
-		assert.Equal(t, logs.Back().Value, "FooXioConn#Close")
+		assert.Equal(t, logs.Front().Value, "BarConn#Close")
+		assert.Equal(t, logs.Back().Value, "FooConn#Close")
 	}
-}
-
-func TestXioBase_close_failed(t *testing.T) {
-	ClearGlobalXioConnCfgs()
-	defer ClearGlobalXioConnCfgs()
-
-	base := NewXioBase()
-
-	base.AddLocalXioConnCfg("foo", FooXioConnCfg{})
-	base.AddLocalXioConnCfg("bar", &BarXioConnCfg{})
-	base.SealLocalXioConnCfgs()
-
-	fooXio := NewFooXio(base)
-	fooConn, _ := fooXio.GetFooConn("foo")
-	assert.NotNil(t, fooConn)
-
-	barXio := NewBarXio(base)
-	barConn, _ := barXio.GetBarConn("bar")
-	assert.NotNil(t, barConn)
-
-	willFooConnFailToClose = true
-
-	err := base.close()
-	assert.False(t, err.IsOk())
-	switch err.Reason().(type) {
-	case FailToCloseXioConn:
-		m := err.Get("Errors").(map[string]Err)
-		assert.Equal(t, m["foo"].ReasonName(), "FooConnFailedToClose")
-	default:
-		assert.Fail(t, err.Error())
-	}
-
-	assert.Equal(t, logs.Len(), 1)
-	assert.Equal(t, logs.Back().Value, "BarXioConn#Close")
 }


### PR DESCRIPTION
### Changes:

This PR renames `XioConn` type to `Conn` and `XioConnCfg` type to `ConnCfg` to shorten names and remove `Xio〜` because of unclearness.

