### PR TITLE
fix!,doc: dax interface that is logic argument should not be embedded sabi.Dax

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ DaxBase serves as an intermediary that connects both of them.
 
 ### Separation of data accesses for each logic
 
-A logic is a function that takes Dax interface as its only one argument.
-The type of this Dax is a type parameter of the logic function, and also a type
+A logic is a function that takes dax interface as its only one argument.
+The type of this dax is a type parameter of the logic function, and also a type
 parameter of the transaction function, Txn, that executes logics.
 
-Therefore, since the type of Dax can be changed for each logic or transaction,
+Therefore, since the type of dax can be changed for each logic or transaction,
 it is possible to limit data accesses used by the logic, by declaring only
 necessary data access methods from among ones defined in DaxBase instance..
 
 At the same time, since all data accesses of a logic is done through this sole
-Dax interface, this Dax interface serves as a list of data access methods used
+dax interface, this dax interface serves as a list of data access methods used
 by a logic.
 
 ### Separation of data accesses by data sources and reintegration of them
@@ -72,7 +72,6 @@ type ( // possible error reasons
 )
 
 type GreetDax interface {
-    sabi.Dax
     UserName() (string, errs.Err)
     Hour() int
     Output(text string) errs.Err

--- a/dax.go
+++ b/dax.go
@@ -510,7 +510,7 @@ func GetDaxConn[C DaxConn](dax Dax, name string) (C, errs.Err) {
 // And after that, this function ends the transaction.
 //
 // During a transaction, it is denied to add or remove any local DaxSrc(s).
-func Txn[D Dax](base DaxBase, logics ...func(dax D) errs.Err) errs.Err {
+func Txn[D any](base DaxBase, logics ...func(dax D) errs.Err) errs.Err {
 	dax, ok := base.(D)
 	if !ok {
 		from := typeNameOf(&base)[1:]
@@ -543,7 +543,7 @@ func Txn[D Dax](base DaxBase, logics ...func(dax D) errs.Err) errs.Err {
 
 // Txn_ is the function that creates a runner function which runs a Txn
 // function.
-func Txn_[D Dax](base DaxBase, logics ...func(dax D) errs.Err) func() errs.Err {
+func Txn_[D any](base DaxBase, logics ...func(dax D) errs.Err) func() errs.Err {
 	return func() errs.Err {
 		return Txn[D](base, logics...)
 	}

--- a/dax_test.go
+++ b/dax_test.go
@@ -1331,8 +1331,8 @@ func TestTxn_oneLogic(t *testing.T) {
 		err := base.Uses("database", FooDaxSrc{})
 		assert.True(t, err.IsOk())
 
-		err = Txn(base, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[FooDaxConn](dax, "database")
+		err = Txn(base, func(dax any) errs.Err {
+			_, err := GetDaxConn[FooDaxConn](dax.(Dax), "database")
 			assert.True(t, err.IsOk())
 			return errs.Ok()
 		})
@@ -1366,12 +1366,12 @@ func TestTxn_twoLogic(t *testing.T) {
 		err = err.IfOk(base.Uses_("file", &BarDaxSrc{}))
 		assert.True(t, err.IsOk())
 
-		err = Txn(base, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[FooDaxConn](dax, "database")
+		err = Txn(base, func(dax any) errs.Err {
+			_, err := GetDaxConn[FooDaxConn](dax.(Dax), "database")
 			assert.True(t, err.IsOk())
 			return errs.Ok()
-		}, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[*BarDaxConn](dax, "file")
+		}, func(dax any) errs.Err {
+			_, err := GetDaxConn[*BarDaxConn](dax.(Dax), "file")
 			assert.True(t, err.IsOk())
 			return errs.Ok()
 		})
@@ -1446,13 +1446,13 @@ func TestTxn_failToRunLogic(t *testing.T) {
 		err = err.IfOk(base.Uses_("file", &BarDaxSrc{}))
 		assert.True(t, err.IsOk())
 
-		err = Txn(base, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[FooDaxConn](dax, "database")
+		err = Txn(base, func(dax any) errs.Err {
+			_, err := GetDaxConn[FooDaxConn](dax.(Dax), "database")
 			assert.True(t, err.IsOk())
 			Logs.PushBack("run logic 1")
 			return errs.New(FailToDoSomething{})
-		}, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[*BarDaxConn](dax, "file")
+		}, func(dax any) errs.Err {
+			_, err := GetDaxConn[*BarDaxConn](dax.(Dax), "file")
 			assert.True(t, err.IsOk())
 			Logs.PushBack("run logic 2")
 			return errs.Ok()
@@ -1502,13 +1502,13 @@ func TestTxn_failToCommit_sync(t *testing.T) {
 
 		WillFailToCommitFooDaxConn = true
 
-		err = Txn(base, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[FooDaxConn](dax, "database")
+		err = Txn(base, func(dax any) errs.Err {
+			_, err := GetDaxConn[FooDaxConn](dax.(Dax), "database")
 			assert.True(t, err.IsOk())
 			Logs.PushBack("run logic 1")
 			return errs.Ok()
-		}, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[*BarDaxConn](dax, "file")
+		}, func(dax any) errs.Err {
+			_, err := GetDaxConn[*BarDaxConn](dax.(Dax), "file")
 			assert.True(t, err.IsOk())
 			Logs.PushBack("run logic 2")
 			return errs.Ok()
@@ -1561,13 +1561,13 @@ func TestTxn_failToCommit_async(t *testing.T) {
 
 		WillFailToCommitBarDaxConn = true
 
-		err = Txn(base, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[FooDaxConn](dax, "database")
+		err = Txn(base, func(dax any) errs.Err {
+			_, err := GetDaxConn[FooDaxConn](dax.(Dax), "database")
 			assert.True(t, err.IsOk())
 			Logs.PushBack("run logic 1")
 			return errs.Ok()
-		}, func(dax Dax) errs.Err {
-			_, err := GetDaxConn[*BarDaxConn](dax, "file")
+		}, func(dax any) errs.Err {
+			_, err := GetDaxConn[*BarDaxConn](dax.(Dax), "file")
 			assert.True(t, err.IsOk())
 			Logs.PushBack("run logic 2")
 			return errs.Ok()
@@ -1617,12 +1617,12 @@ func TestTxn_runner(t *testing.T) {
 
 		err := base.Uses("database", FooDaxSrc{}).
 			IfOk(base.Uses_("file", &BarDaxSrc{})).
-			IfOk(Txn_(base, func(dax Dax) errs.Err {
-				_, err := GetDaxConn[FooDaxConn](dax, "database")
+			IfOk(Txn_(base, func(dax any) errs.Err {
+				_, err := GetDaxConn[FooDaxConn](dax.(Dax), "database")
 				assert.True(t, err.IsOk())
 				return errs.Ok()
-			}, func(dax Dax) errs.Err {
-				_, err := GetDaxConn[*BarDaxConn](dax, "file")
+			}, func(dax any) errs.Err {
+				_, err := GetDaxConn[*BarDaxConn](dax.(Dax), "file")
 				assert.True(t, err.IsOk())
 				return errs.Ok()
 			}))

--- a/example_dax_test.go
+++ b/example_dax_test.go
@@ -174,7 +174,6 @@ func ExampleDaxBase() {
 	}
 
 	type GetSetDax struct {
-		sabi.Dax
 		// ...
 	}
 
@@ -184,7 +183,6 @@ func ExampleDaxBase() {
 	}
 
 	type OutputDax struct {
-		sabi.Dax
 		// ...
 	}
 
@@ -248,7 +246,6 @@ func ExampleTxn() {
 	defer base.Close()
 
 	type GetSetDax struct {
-		sabi.Dax
 		// ...
 	}
 


### PR DESCRIPTION
Because `sabi.GetDaxConn` should not be called in logic functions. 

In addition, in the case that DaxSrc(s) and DaxConn(s) are not needed, pairs of a logic function and a dax interface enable to be applied according to the style of this framework even without this framework.