### PR TITLE
fix: changed inappropriate method names

### DIFF
--- a/data-hub.go
+++ b/data-hub.go
@@ -220,8 +220,8 @@ func (hub *dataHubImpl) Disuses(name string) {
 	maps.DeleteFunc(hub.dataSrcMap, func(nm string, ptr *dataSrcContainer) bool {
 		return ptr.local && nm == name
 	})
-	hub.localDataSrcList.removeAndCloseLocalContainerPtrDidSetupByName(name)
-	hub.localDataSrcList.removeAndCloseLocalContainerPtrNotSetupByName(name)
+	hub.localDataSrcList.removeAndCloseContainerPtrDidSetupByName(name)
+	hub.localDataSrcList.removeAndCloseContainerPtrNotSetupByName(name)
 }
 
 func (hub *dataHubImpl) Close() {

--- a/data-src.go
+++ b/data-src.go
@@ -83,10 +83,10 @@ func (list *dataSrcList) removeContainerPtrNotSetup(ptr *dataSrcContainer) {
 	}
 }
 
-func (list *dataSrcList) removeAndCloseLocalContainerPtrNotSetupByName(name string) {
+func (list *dataSrcList) removeAndCloseContainerPtrNotSetupByName(name string) {
 	ptr := list.notSetupHead
 	for ptr != nil {
-		if ptr.local && ptr.name == name {
+		if ptr.name == name {
 			list.removeContainerPtrNotSetup(ptr)
 			ptr.ds.Close()
 		}
@@ -127,10 +127,10 @@ func (list *dataSrcList) removeContainerPtrDidSetup(ptr *dataSrcContainer) {
 	}
 }
 
-func (list *dataSrcList) removeAndCloseLocalContainerPtrDidSetupByName(name string) {
+func (list *dataSrcList) removeAndCloseContainerPtrDidSetupByName(name string) {
 	ptr := list.didSetupHead
 	for ptr != nil {
-		if ptr.local && ptr.name == name {
+		if ptr.name == name {
 			list.removeContainerPtrDidSetup(ptr)
 			ptr.ds.Close()
 		}

--- a/data-src.go
+++ b/data-src.go
@@ -86,7 +86,7 @@ func (list *dataSrcList) removeContainerPtrNotSetup(ptr *dataSrcContainer) {
 func (list *dataSrcList) removeAndCloseContainerPtrNotSetupByName(name string) {
 	ptr := list.notSetupHead
 	for ptr != nil {
-    next := ptr.next
+		next := ptr.next
 		if ptr.name == name {
 			list.removeContainerPtrNotSetup(ptr)
 			ptr.ds.Close()
@@ -131,7 +131,7 @@ func (list *dataSrcList) removeContainerPtrDidSetup(ptr *dataSrcContainer) {
 func (list *dataSrcList) removeAndCloseContainerPtrDidSetupByName(name string) {
 	ptr := list.didSetupHead
 	for ptr != nil {
-    next := ptr.next
+		next := ptr.next
 		if ptr.name == name {
 			list.removeContainerPtrDidSetup(ptr)
 			ptr.ds.Close()

--- a/data-src.go
+++ b/data-src.go
@@ -86,11 +86,12 @@ func (list *dataSrcList) removeContainerPtrNotSetup(ptr *dataSrcContainer) {
 func (list *dataSrcList) removeAndCloseContainerPtrNotSetupByName(name string) {
 	ptr := list.notSetupHead
 	for ptr != nil {
+    next := ptr.next
 		if ptr.name == name {
 			list.removeContainerPtrNotSetup(ptr)
 			ptr.ds.Close()
 		}
-		ptr = ptr.next
+		ptr = next
 	}
 }
 
@@ -130,11 +131,12 @@ func (list *dataSrcList) removeContainerPtrDidSetup(ptr *dataSrcContainer) {
 func (list *dataSrcList) removeAndCloseContainerPtrDidSetupByName(name string) {
 	ptr := list.didSetupHead
 	for ptr != nil {
+    next := ptr.next
 		if ptr.name == name {
 			list.removeContainerPtrDidSetup(ptr)
 			ptr.ds.Close()
 		}
-		ptr = ptr.next
+		ptr = next
 	}
 }
 


### PR DESCRIPTION
This PR changes the following method names because whether a `DataSrcContainer` is local is determined by whether the `DataSrcList` that stores it is local.

- `removeAndCloseLocalContainerPtrDidSetupByName` -> `removeAndCloseContainerPtrDidSetupByName`
- `removeAndCloseLocalContainerPtrNotSetupByName` -> `removeAndCloseContainerPtrNotSetupByName`

The unit tests of those method is lack and I'll add them another PR.