### PR TITLE
update!: add context.Context support to Run, Txn and DataAcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ transactional operations.
 
 ```go
 import (
+    "context"
     "github.com/sttk/errs"
     "github.com/sttk/sabi"
 )
@@ -189,7 +190,8 @@ func run() errs.Err {
 
     // Execute application logic within a transaction.
     // MyLogic performs data operations via DataHub.
-    return sabi.Txn(data, MyLogic)
+    ctx := context.Background()
+    return sabi.Txn(data, ctx, MyLogic)
 }
 ```
 

--- a/data-acc.go
+++ b/data-acc.go
@@ -4,7 +4,10 @@
 
 package sabi
 
-import "github.com/sttk/errs"
+import (
+	"context"
+	"github.com/sttk/errs"
+)
 
 // The interface that aggregates data access operations to external data services
 // into logical units, with methods providing default implementations.
@@ -23,4 +26,11 @@ import "github.com/sttk/errs"
 // enabling a clear separation and aggregation of data input/output methods.
 type DataAcc interface {
 	getDataConn(name, dataConnType string) (DataConn, errs.Err)
+
+	setContext(ctx context.Context)
+
+	// Returns the context associated with this DataAcc instance.
+	// This context is intended to be used by data access methods within DataAcc
+	// implementations to support cancellation and timeouts.
+	Context() context.Context
 }

--- a/data-acc_test.go
+++ b/data-acc_test.go
@@ -2,6 +2,7 @@ package sabi_test
 
 import (
 	"container/list"
+	"context"
 	"fmt"
 	"testing"
 
@@ -175,6 +176,11 @@ type FooDataAcc struct {
 }
 
 func (data *FooDataAcc) GetValue() (string, errs.Err) {
+	ctx := data.Context()
+	if ctx == nil {
+		panic("The context is nil")
+	}
+
 	conn, err := sabi.GetDataConn[*FooDataConn](data, "foo")
 	if err.IsNotOk() {
 		return "", err
@@ -187,6 +193,11 @@ type BarDataAcc struct {
 }
 
 func (data *BarDataAcc) SetValue(text string) errs.Err {
+	ctx := data.Context()
+	if ctx == nil {
+		panic("The context is nil")
+	}
+
 	conn, err := sabi.GetDataConn[*BarDataConn](data, "bar")
 	if err.IsNotOk() {
 		return err
@@ -212,51 +223,6 @@ func NewSampleDataHub() sabi.DataHub {
 }
 
 ///
-
-func TestLogicArgument(t *testing.T) {
-	t.Run("test", func(t *testing.T) {
-		sabi.ResetGlobalVariables()
-		defer sabi.ResetGlobalVariables()
-
-		logger := list.New()
-
-		sabi.Uses("foo", &FooDataSrc{id: 1, text: "hello", logger: logger, will_fail: false})
-		sabi.Uses("bar", &BarDataSrc{id: 2, logger: logger})
-
-		err := sabi.Setup().IfOkThen(func() errs.Err {
-			defer sabi.Shutdown()
-
-			hub := NewSampleDataHub()
-			defer hub.Close()
-
-			return sample_logic(hub.(SampleData))
-		})
-		assert.True(t, err.IsOk())
-
-		elem := logger.Front()
-		assert.Equal(t, elem.Value, "FooDataSrc 1 setupped")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "BarDataSrc 2 setupped")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "FooDataSrc 1 created FooDataConn")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "BarDataSrc 2 created BarDataConn")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "BarDataConn.text = hello")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "BarDataConn 2 closed")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "FooDataConn 1 closed")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "BarDataSrc.text = ")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "BarDataSrc 2 closed")
-		elem = elem.Next()
-		assert.Equal(t, elem.Value, "FooDataSrc 1 closed")
-		elem = elem.Next()
-		assert.Nil(t, elem)
-	})
-}
 
 func TestDataHubRunUsingGlobal(t *testing.T) {
 	t.Run("test", func(t *testing.T) {
@@ -286,7 +252,8 @@ func TestDataHubRunUsingGlobal(t *testing.T) {
 			}()
 			defer hub.Close()
 
-			return sabi.Run(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Run(hub, ctx, sample_logic)
 		})
 		assert.True(t, err.IsOk())
 
@@ -343,7 +310,8 @@ func TestDataHubRunUsingLocal(t *testing.T) {
 			hub.Uses("foo", &FooDataSrc{id: 1, text: "hello", logger: logger, will_fail: false})
 			hub.Uses("bar", &BarDataSrc{id: 2, logger: logger})
 
-			return sabi.Run(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Run(hub, ctx, sample_logic)
 		})
 		assert.True(t, err.IsOk())
 
@@ -398,7 +366,8 @@ func TestDataHubRunUsingLocal(t *testing.T) {
 			hub.Uses("foo", &FooDataSrc{id: 1, text: "hello", logger: logger, will_fail: true})
 			hub.Uses("bar", &BarDataSrc{id: 2, logger: logger})
 
-			return sabi.Run(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Run(hub, ctx, sample_logic)
 		})
 		switch r := err.Reason().(type) {
 		case sabi.FailToSetupLocalDataSrcs:
@@ -444,7 +413,8 @@ func TestDataHubRunUsingGlobalAndLocal(t *testing.T) {
 
 			hub.Uses("foo", &FooDataSrc{id: 2, text: "Hello", logger: logger, will_fail: false})
 
-			return sabi.Run(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Run(hub, ctx, sample_logic)
 		})
 		assert.True(t, err.IsOk())
 
@@ -501,7 +471,8 @@ func TestDataHubTxnUsingGlobal(t *testing.T) {
 			}()
 			defer hub.Close()
 
-			return sabi.Txn(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Txn(hub, ctx, sample_logic)
 		})
 		assert.True(t, err.IsOk())
 
@@ -570,7 +541,8 @@ func TestDataHubTxnUsingLocal(t *testing.T) {
 			hub.Uses("foo", &FooDataSrc{id: 1, text: "Hello", logger: logger, will_fail: false})
 			hub.Uses("bar", &BarDataSrc{id: 2, logger: logger})
 
-			return sabi.Txn(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Txn(hub, ctx, sample_logic)
 		})
 		assert.True(t, err.IsOk())
 
@@ -637,7 +609,8 @@ func TestDataHubTxnUsingLocal(t *testing.T) {
 			hub.Uses("foo", &FooDataSrc{id: 1, text: "Hello", logger: logger, will_fail: true})
 			hub.Uses("bar", &BarDataSrc{id: 2, logger: logger})
 
-			return sabi.Txn(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Txn(hub, ctx, sample_logic)
 		})
 		switch r := err.Reason().(type) {
 		case sabi.FailToSetupLocalDataSrcs:
@@ -680,7 +653,8 @@ func TestDataHubTxnUsingLocal(t *testing.T) {
 			hub.Uses("foo", &FooDataSrc{id: 1, text: "Hello", logger: logger, will_fail: false})
 			hub.Uses("bar", &BarDataSrc{id: 2, logger: logger})
 
-			return sabi.Txn(hub, failing_logic)
+			ctx := context.Background()
+			return sabi.Txn(hub, ctx, failing_logic)
 		})
 		assert.Equal(t, err.Reason(), "ZZZ")
 
@@ -728,7 +702,8 @@ func TestDataHubTxnUsingGlobalAndLocal(t *testing.T) {
 
 			hub.Uses("foo", &FooDataSrc{id: 2, text: "Hello", logger: logger, will_fail: false})
 
-			return sabi.Txn(hub, sample_logic)
+			ctx := context.Background()
+			return sabi.Txn(hub, ctx, sample_logic)
 		})
 		assert.True(t, err.IsOk())
 

--- a/data-hub.go
+++ b/data-hub.go
@@ -5,6 +5,7 @@
 package sabi
 
 import (
+	"context"
 	"maps"
 
 	"github.com/sttk/errs"
@@ -186,6 +187,9 @@ type dataHubImpl struct {
 	dataConnList     dataConnList
 	dataConnMap      map[string]*dataConnContainer
 	fixed            bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // Creates a new DataHub instance.
@@ -312,9 +316,26 @@ func (hub *dataHubImpl) rollback() {
 }
 
 func (hub *dataHubImpl) end() {
+	if hub.cancel != nil {
+		cancel := hub.cancel
+		hub.cancel = nil
+		cancel()
+	}
+	if hub.ctx != nil {
+		hub.ctx = nil
+	}
+
 	clear(hub.dataConnMap)
 	hub.dataConnList.closeDataConns()
 	hub.fixed = false
+}
+
+func (hub *dataHubImpl) Context() context.Context {
+	return hub.ctx
+}
+
+func (hub *dataHubImpl) setContext(ctx context.Context) {
+	hub.ctx, hub.cancel = context.WithCancel(ctx)
 }
 
 func (hub *dataHubImpl) getDataConn(name string, dataConnType string) (DataConn, errs.Err) {
@@ -368,16 +389,18 @@ func GetDataConn[C DataConn](data any, name string) (C, errs.Err) {
 
 // Executes a given logic function without transaction control.
 //
-// This method sets up local data sources, runs the provided closure,
-// and then cleans up the DataHub's session resources. It does not
-// perform commit or rollback operations.
-func Run[D any](hub DataHub, logic func(D) errs.Err) errs.Err {
+// This method sets a context, then sets up local data sources, runs the provided
+// closure, and then cleans up the DataHub's session resources. It does not perform
+// commit or rollback operations.
+func Run[D any](hub DataHub, ctx context.Context, logic func(D) errs.Err) errs.Err {
 	data, ok := hub.(D)
 	if !ok {
 		fromType := typeNameOf(&hub)[1:]
 		toType := typeNameOfTypeParam[D]()
 		return errs.New(FailToCastDataHub{CastFromType: fromType, CastToType: toType})
 	}
+
+	hub.setContext(ctx)
 
 	err := hub.begin()
 	if err.IsNotOk() {
@@ -395,19 +418,21 @@ func Run[D any](hub DataHub, logic func(D) errs.Err) errs.Err {
 
 // Executes a given logic function within a transaction.
 //
-// This method first sets up local data sources, then runs the provided closure.
-// If the closure returns errs.Ok, it attempts to commit all changes. If the commit fails,
-// or if the logic function itself returns an errs.Err, a rollback operation
-// is performed. After succeeding PreCommit and Commit methods of all DataConn(s),
-// PostCommit methods of all DataConn(s) are executed.
+// This method sets a context, then first sets up local data sources, then runs the
+// provided closure. If the closure returns errs.Ok, it attempts to commit all
+// changes. If the commit fails, or if the logic function itself returns an errs.Err,
+// a rollback operation is performed. After succeeding PreCommit and Commit methods
+// of all DataConn(s), PostCommit methods of all DataConn(s) are executed.
 // Finally, it cleans up the DataHub's session resources.
-func Txn[D any](hub DataHub, logic func(D) errs.Err) errs.Err {
+func Txn[D any](hub DataHub, ctx context.Context, logic func(D) errs.Err) errs.Err {
 	data, ok := hub.(D)
 	if !ok {
 		fromType := typeNameOf(&hub)[1:]
 		toType := typeNameOfTypeParam[D]()
 		return errs.New(FailToCastDataHub{CastFromType: fromType, CastToType: toType})
 	}
+
+	hub.setContext(ctx)
 
 	err := hub.begin()
 	if err.IsNotOk() {

--- a/doc.go
+++ b/doc.go
@@ -28,6 +28,7 @@ This framework brings clear separation and robustness to Go application design.
 The following is a sample code using this framework
 
 	import (
+		"context"
 		"os"
 
 		"github.com/sttk/sabi"
@@ -139,7 +140,8 @@ The following is a sample code using this framework
 
 		// Execute application logic within a transaction.
 		// my_logic performs data operations via DataHub.
-		return sabi.Txn(data, MyLogic)
+		ctx := context.Background()
+		return sabi.Txn(data, ctx, MyLogic)
 	}
 */
 package sabi


### PR DESCRIPTION
This PR changes that `DataAcc` methods can retrieve a `context.Context` which was passed as an argument of `sabi.Txn` and `sabi.Run`.

Since most external service client APIs require `context.Context`, this change allows the `context.Context` provided on a per-`Txn` or per-`Run` basis to be passed to them.

Closes #89 