### PR TITLE
cicd: updated the minimum supprting Go version to 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gover: ['~1.21', '~1.22', '~1.23', '~1.24', '~1.25', '~1.26']
+        gover: ['~1.23', '~1.24', '~1.25', '~1.26']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Because `dyld[53818]: missing LC_UUID load command` error occurs on macosx on go 1.21 and go 1.22.