### PR TITLE
update!: introduced ErrEntry for error reasons which store multiple Errs

### DIFF
--- a/async-group.go
+++ b/async-group.go
@@ -10,29 +10,10 @@ import (
 	"github.com/sttk/errs"
 )
 
-// IndexedErr represents an error that occurred during an asynchronous task,
-// paired with the index of the task to identify which execution failed.
-//
-// It is a struct that associates an error value (errs.Err) with an integer index.
-//
-// In concurrent or batch processing, multiple tasks are executed asynchronously.
-// If one or more tasks fail, it is crucial to know which task generated which error.
-// IndexedErr provides a mapping between the task (via its index) and the resulting error,
-// allowing callers to pinpoint the source of failure (e.g., matching the error to a
-// specific data source or connection index).
-//
-// Typically, you receive a slice of IndexedErr created by AsyncGroup. You can
-// iterate over this slice and use the Index field to retrieve the original context
-// or metadata of the failed task, and the Err field to handle the error itself.
-type IndexedErr struct {
-	// Index is the task identifier or sequence number (typically the index in a slice
-	// of tasks or resources) associated with the failed asynchronous execution.
-	// This index is determined by the order in which they were added to AsyncGroup.
+type ErrEntry struct {
 	Index int
-
-	// Err is the error returned by the asynchronous task. It uses the errs.Err type
-	// from the "github.com/sttk/errs" package to represent the failure details.
-	Err errs.Err
+	Name  string
+	Err   errs.Err
 }
 
 // AsyncGroup coordinates the execution of multiple asynchronous tasks and
@@ -47,8 +28,9 @@ type IndexedErr struct {
 // allows executing these operations in separate goroutines while safely aggregating all errors
 // that occur, along with their order or resource index.
 type AsyncGroup struct {
-	ierrs  []IndexedErr
+	errors []ErrEntry
 	_index int
+	_name  string
 	wg     sync.WaitGroup
 	mutex  sync.Mutex
 }
@@ -63,22 +45,22 @@ type AsyncGroup struct {
 // Once fn completes, the WaitGroup counter is decremented.
 func (ag *AsyncGroup) Add(fn func() errs.Err) {
 	ag.wg.Add(1)
-	go func(index int) {
+	go func(index int, name string) {
 		defer ag.wg.Done()
 		err := fn()
 		if err.IsNotOk() {
 			ag.mutex.Lock()
 			defer ag.mutex.Unlock()
-			ag.addErr(index, err)
+			ag.addErr(index, name, err)
 		}
-	}(ag._index)
+	}(ag._index, ag._name)
 }
 
-func (ag *AsyncGroup) addErr(index int, err errs.Err) {
-	ag.ierrs = append(ag.ierrs, IndexedErr{Index: index, Err: err})
+func (ag *AsyncGroup) addErr(index int, name string, err errs.Err) {
+	ag.errors = append(ag.errors, ErrEntry{Index: index, Name: name, Err: err})
 }
 
-func (ag *AsyncGroup) join() []IndexedErr {
+func (ag *AsyncGroup) join() []ErrEntry {
 	ag.wg.Wait()
-	return ag.ierrs
+	return ag.errors
 }

--- a/async-group.go
+++ b/async-group.go
@@ -10,10 +10,24 @@ import (
 	"github.com/sttk/errs"
 )
 
+// ErrEntry represents an error encountered during a specific task,
+// associated with its identifier and name.
+//
+// This struct is used in concurrent or batch processing to track which
+// specific task generated which error, allowing for precise identification
+// and handling of failures.
 type ErrEntry struct {
+	// Index is the task identifier or sequence number (typically the index
+	// in a slice of tasks) associated with the failed execution.
 	Index int
-	Name  string
-	Err   errs.Err
+
+	// Name is the descriptive identifier or label assigned to the task
+	// or resource that encountered the error.
+	Name string
+
+	// Err is the error value returned by the task. It uses the errs.Err type
+	// from the "github.com/sttk/errs" package to represent the failure details.
+	Err errs.Err
 }
 
 // AsyncGroup coordinates the execution of multiple asynchronous tasks and

--- a/async-group_test.go
+++ b/async-group_test.go
@@ -27,11 +27,12 @@ func TestAsyncGroup(t *testing.T) {
 		}
 
 		ag._index = 123
+		ag._name = "foo"
 		ag.Add(fn)
 		assert.False(t, executed)
 
-		ierrs := ag.join()
-		assert.Len(t, ierrs, 0)
+		errors := ag.join()
+		assert.Len(t, errors, 0)
 		assert.True(t, executed)
 	})
 
@@ -48,18 +49,20 @@ func TestAsyncGroup(t *testing.T) {
 		}
 
 		ag._index = 123
+		ag._name = "foo"
 		ag.Add(fn)
 		assert.False(t, executed)
 
-		ierrs := ag.join()
-		assert.Len(t, ierrs, 1)
+		errors := ag.join()
+		assert.Len(t, errors, 1)
 		assert.True(t, executed)
 
-		assert.Equal(t, ierrs[0].Index, 123)
-		switch ierrs[0].Err.Reason().(type) {
+		assert.Equal(t, errors[0].Index, 123)
+		assert.Equal(t, errors[0].Name, "foo")
+		switch errors[0].Err.Reason().(type) {
 		case FailToDoSomething:
 		default:
-			assert.Fail(t, ierrs[0].Err.Error())
+			assert.Fail(t, errors[0].Err.Error())
 		}
 	})
 
@@ -75,7 +78,7 @@ func TestAsyncGroup(t *testing.T) {
 		executed2 := false
 
 		fn0 := func() errs.Err {
-			time.Sleep(200)
+			time.Sleep(800)
 			executed0 = true
 			return errs.New(Reason0{})
 		}
@@ -85,22 +88,51 @@ func TestAsyncGroup(t *testing.T) {
 			return errs.New(Reason1{})
 		}
 		fn2 := func() errs.Err {
-			time.Sleep(800)
+			time.Sleep(100)
 			executed2 = true
 			return errs.New(Reason2{})
 		}
 
 		ag._index = 12
+		ag._name = "foo"
 		ag.Add(fn0)
 		ag._index = 34
+		ag._name = "bar"
 		ag.Add(fn1)
 		ag._index = 56
+		ag._name = "baz"
 		ag.Add(fn2)
 
-		ierrs := ag.join()
-		assert.Len(t, ierrs, 3)
+		errors := ag.join()
+		assert.Len(t, errors, 3)
 		assert.True(t, executed0)
 		assert.True(t, executed1)
 		assert.True(t, executed2)
+
+    /*
+		assert.Equal(t, errors[0].Index, 56)
+		assert.Equal(t, errors[0].Name, "baz")
+		switch errors[0].Err.Reason().(type) {
+		case Reason2:
+		default:
+			assert.Fail(t, errors[0].Err.Error())
+		}
+
+		assert.Equal(t, errors[1].Index, 34)
+		assert.Equal(t, errors[1].Name, "bar")
+		switch errors[1].Err.Reason().(type) {
+		case Reason1:
+		default:
+			assert.Fail(t, errors[0].Err.Error())
+		}
+
+		assert.Equal(t, errors[2].Index, 12)
+		assert.Equal(t, errors[2].Name, "foo")
+		switch errors[2].Err.Reason().(type) {
+		case Reason0:
+		default:
+			assert.Fail(t, errors[2].Err.Error())
+		}
+    */
 	})
 }

--- a/async-group_test.go
+++ b/async-group_test.go
@@ -109,30 +109,32 @@ func TestAsyncGroup(t *testing.T) {
 		assert.True(t, executed1)
 		assert.True(t, executed2)
 
-    /*
-		assert.Equal(t, errors[0].Index, 56)
-		assert.Equal(t, errors[0].Name, "baz")
-		switch errors[0].Err.Reason().(type) {
-		case Reason2:
-		default:
-			assert.Fail(t, errors[0].Err.Error())
-		}
-
-		assert.Equal(t, errors[1].Index, 34)
-		assert.Equal(t, errors[1].Name, "bar")
-		switch errors[1].Err.Reason().(type) {
-		case Reason1:
-		default:
-			assert.Fail(t, errors[0].Err.Error())
-		}
-
-		assert.Equal(t, errors[2].Index, 12)
-		assert.Equal(t, errors[2].Name, "foo")
-		switch errors[2].Err.Reason().(type) {
-		case Reason0:
-		default:
-			assert.Fail(t, errors[2].Err.Error())
-		}
-    */
+		// Note: These assertions are temporarily disabled because goroutine scheduling
+		// is non-deterministic. Relying on time.Sleep does not ensure the order of
+		// execution, leading to flaky tests.
+		//
+		//assert.Equal(t, errors[0].Index, 56)
+		//assert.Equal(t, errors[0].Name, "baz")
+		//switch errors[0].Err.Reason().(type) {
+		//case Reason2:
+		//default:
+		//	assert.Fail(t, errors[0].Err.Error())
+		//}
+		//
+		//assert.Equal(t, errors[1].Index, 34)
+		//assert.Equal(t, errors[1].Name, "bar")
+		//switch errors[1].Err.Reason().(type) {
+		//case Reason1:
+		//default:
+		//	assert.Fail(t, errors[0].Err.Error())
+		//}
+		//
+		//assert.Equal(t, errors[2].Index, 12)
+		//assert.Equal(t, errors[2].Name, "foo")
+		//switch errors[2].Err.Reason().(type) {
+		//case Reason0:
+		//default:
+		//	assert.Fail(t, errors[2].Err.Error())
+		//}
 	})
 }

--- a/data-conn.go
+++ b/data-conn.go
@@ -15,7 +15,7 @@ type /* error reasons */ (
 	// which connections encountered issues and what the underlying errors were before
 	// the actual commit was attempted.
 	FailToPreCommitDataConn struct {
-		Errors []DataConnErr
+		Errors []ErrEntry
 	}
 
 	// FailToCommitDataConn represents an error reason indicating that one or more
@@ -23,7 +23,7 @@ type /* error reasons */ (
 	// errors from the failed connections, which is useful for diagnosing failures that
 	// happened while finalizing the transactions on those connections.
 	FailToCommitDataConn struct {
-		Errors []DataConnErr
+		Errors []ErrEntry
 	}
 
 	// FailToPostCommitDataConn represents an error reason indicating that one or more
@@ -32,19 +32,9 @@ type /* error reasons */ (
 	// successfully, subsequent cleanup or follow-up operations on the connections failed.
 	// It contains a list of individual connection errors for diagnosis.
 	FailToPostCommitDataConn struct {
-		Errors []DataConnErr
+		Errors []ErrEntry
 	}
 )
-
-// DataConnErr represents a pair of a data connection's name and the error it encountered.
-// It is used to report failures associated with specific connections during transaction
-// phases such as pre-commit, commit, post-commit, or rollback.
-type DataConnErr struct {
-	// Name is the identifier of the data connection that failed.
-	Name string
-	// Err is the error returned by the data connection.
-	Err errs.Err
-}
 
 // DataConn is an interface representing a database or external resource connection
 // that participates in transaction management. It defines methods for managing the
@@ -165,22 +155,20 @@ func (mgr *dataConnManager) commit(reports []TxnFailureReport) errs.Err {
 		if mgr.list[i].conn == nil {
 			continue
 		}
+		ag._name = mgr.list[i].name
 		ag._index = ii
 		ii++
 		if err := mgr.list[i].conn.PreCommit(&ag); err.IsNotOk() {
-			ag.addErr(ag._index, err)
+			ag.addErr(ag._index, ag._name, err)
 			break
 		}
 	}
-	indexed_errors := ag.join()
+	errors := ag.join()
 
-	if len(indexed_errors) > 0 {
-		errors := make([]DataConnErr, len(indexed_errors))
-		for i := range indexed_errors {
-			idx := indexed_errors[i].Index
-			reports[idx].Cause = TxnFailureCause{State: LogicFailure, Err: indexed_errors[i].Err}
-			errors[i].Name = reports[idx].DataConnName
-			errors[i].Err = indexed_errors[i].Err
+	if len(errors) > 0 {
+		for i := range errors {
+			idx := errors[i].Index
+			reports[idx].Cause = TxnFailureCause{State: LogicFailure, Err: errors[i].Err}
 		}
 		return errs.New(FailToPreCommitDataConn{Errors: errors})
 	}
@@ -191,24 +179,22 @@ func (mgr *dataConnManager) commit(reports []TxnFailureReport) errs.Err {
 		if mgr.list[i].conn == nil {
 			continue
 		}
+		ag._name = mgr.list[i].name
 		ag._index = ii
 		ii++
 		if !mgr.list[i].conn.IsCommitted() {
 			if err := mgr.list[i].conn.Commit(&ag); err.IsNotOk() {
-				ag.addErr(ag._index, err)
+				ag.addErr(ag._index, ag._name, err)
 				break
 			}
 		}
 	}
-	indexed_errors = ag.join()
+	errors = ag.join()
 
-	if len(indexed_errors) > 0 {
-		errors := make([]DataConnErr, len(indexed_errors))
-		for i := range indexed_errors {
-			idx := indexed_errors[i].Index
-			reports[idx].Cause = TxnFailureCause{State: CommitFailure, Err: indexed_errors[i].Err}
-			errors[i].Name = reports[idx].DataConnName
-			errors[i].Err = indexed_errors[i].Err
+	if len(errors) > 0 {
+		for i := range errors {
+			idx := errors[i].Index
+			reports[idx].Cause = TxnFailureCause{State: CommitFailure, Err: errors[i].Err}
 		}
 		return errs.New(FailToCommitDataConn{Errors: errors})
 	}
@@ -221,22 +207,20 @@ func (mgr *dataConnManager) commit(reports []TxnFailureReport) errs.Err {
 		if mgr.list[i].conn == nil {
 			continue
 		}
+		ag._name = mgr.list[i].name
 		ag._index = ii
 		ii++
 		if err := mgr.list[i].conn.PostCommit(&ag); err.IsNotOk() {
-			ag.addErr(ag._index, err)
+			ag.addErr(ag._index, ag._name, err)
 			// don't break
 		}
 	}
-	indexed_errors = ag.join()
+	errors = ag.join()
 
-	if len(indexed_errors) > 0 {
-		errors := make([]DataConnErr, len(indexed_errors))
-		for i := range indexed_errors {
-			idx := indexed_errors[i].Index
-			reports[idx].Cause = TxnFailureCause{State: PostCommitFailure, Err: indexed_errors[i].Err}
-			errors[i].Name = reports[idx].DataConnName
-			errors[i].Err = indexed_errors[i].Err
+	if len(errors) > 0 {
+		for i := range errors {
+			idx := errors[i].Index
+			reports[idx].Cause = TxnFailureCause{State: PostCommitFailure, Err: errors[i].Err}
 		}
 		return errs.New(FailToPostCommitDataConn{Errors: errors})
 	}
@@ -251,6 +235,7 @@ func (mgr *dataConnManager) rollback(reports []TxnFailureReport) {
 		if mgr.list[i].conn == nil {
 			continue
 		}
+		ag._name = mgr.list[i].name
 		ag._index = ii
 		ii++
 		if mgr.list[i].conn.IsCommitted() {
@@ -263,17 +248,17 @@ func (mgr *dataConnManager) rollback(reports []TxnFailureReport) {
 			continue
 		}
 		if err := mgr.list[i].conn.Rollback(&ag); err.IsNotOk() {
-			ag.addErr(ag._index, err)
+			ag.addErr(ag._index, ag._name, err)
 		} else {
 			reports[ag._index].Rollback.State = NoneByRolledBack
 		}
 	}
-	indexed_errors := ag.join()
+	errors := ag.join()
 
-	if len(indexed_errors) > 0 {
-		for i := range indexed_errors {
-			idx := indexed_errors[i].Index
-			reports[idx].Rollback = TxnFailureRollback{State: RollbackFailure, Err: indexed_errors[i].Err}
+	if len(errors) > 0 {
+		for i := range errors {
+			idx := errors[i].Index
+			reports[idx].Rollback = TxnFailureRollback{State: RollbackFailure, Err: errors[i].Err}
 		}
 	}
 

--- a/data-hub.go
+++ b/data-hub.go
@@ -15,14 +15,14 @@ type /* error reasons */ (
 	// global data sources failed to initialize during their setup phase. It wraps the
 	// list of individual errors encountered by the data sources.
 	FailToSetupGlobalDataSrcs struct {
-		Errors []DataSrcErr
+		Errors []ErrEntry
 	}
 
 	// FailToSetupLocalDataSrcs represents an error reason indicating that one or more
 	// local data sources registered to a specific DataHub failed to initialize when the
 	// hub began transaction execution. It wraps the list of individual initialization errors.
 	FailToSetupLocalDataSrcs struct {
-		Errors []DataSrcErr
+		Errors []ErrEntry
 	}
 
 	// NoDataSrcToCreateDataConn represents an error reason indicating that there is no

--- a/data-src.go
+++ b/data-src.go
@@ -8,17 +8,6 @@ import (
 	"github.com/sttk/errs"
 )
 
-// DataSrcErr represents an error that occurred in a data source, associating
-// the name of the data source with the specific error returned during its
-// lifecycle (such as setup or initialization). This allows callers to identify
-// which data source encountered an issue and handle the failure accordingly.
-type DataSrcErr struct {
-	// Name is the identifier of the data source that experienced the error.
-	Name string
-	// Err is the error details returned by the data source.
-	Err errs.Err
-}
-
 // DataSrc is an interface representing a factory or connection pool for data sources
 // (such as databases, external APIs, or files) that need initialization and cleanup.
 // It manages the lifecycle of the data source before connections are created, and
@@ -94,25 +83,30 @@ func (mgr *dataSrcManager) close() {
 	mgr.listUnready = nil
 }
 
-func (mgr *dataSrcManager) setup() []DataSrcErr {
+func (mgr *dataSrcManager) setup() []ErrEntry {
 	if len(mgr.listUnready) == 0 {
 		return nil
 	}
 
 	ag := AsyncGroup{}
+	ii := 0
+	nDone := 0
 	for i := range mgr.listUnready {
-		if mgr.listUnready[i].ds != nil {
-			ag._index = i
-			if err := mgr.listUnready[i].ds.Setup(&ag); err.IsNotOk() {
-				ag.addErr(ag._index, err)
-				break
-			}
+		if mgr.listUnready[i].ds == nil {
+			continue
+		}
+		ag._name = mgr.listUnready[i].name
+		ag._index = ii
+		ii++
+		if err := mgr.listUnready[i].ds.Setup(&ag); err.IsNotOk() {
+			ag.addErr(ag._index, ag._name, err)
+			nDone = i
+			break
 		}
 	}
-	nDone := ag._index
-	indexedErrors := ag.join()
+	errors := ag.join()
 
-	if len(indexedErrors) == 0 {
+	if len(errors) == 0 {
 		for i := range mgr.listUnready {
 			if mgr.listUnready[i].ds != nil {
 				mgr.listReady = append(mgr.listReady, mgr.listUnready[i])
@@ -126,16 +120,11 @@ func (mgr *dataSrcManager) setup() []DataSrcErr {
 				mgr.listUnready[i].ds.Close()
 			}
 		}
-		errors := make([]DataSrcErr, len(indexedErrors))
-		for i, idxErr := range indexedErrors {
-			errors[i].Name = mgr.listUnready[idxErr.Index].name
-			errors[i].Err = idxErr.Err
-		}
 		return errors
 	}
 }
 
-func (mgr *dataSrcManager) setupWithOrder(names []string) []DataSrcErr {
+func (mgr *dataSrcManager) setupWithOrder(names []string) []ErrEntry {
 	if len(mgr.listUnready) == 0 {
 		return nil
 	}
@@ -163,30 +152,37 @@ func (mgr *dataSrcManager) setupWithOrder(names []string) []DataSrcErr {
 	}
 
 	ag := AsyncGroup{}
+	ii := 0
 	nDone := 0
 	for orderIndex, listIndexPlusOffset := range orderedIndexes {
-		if listIndexPlusOffset > 0 { // Ignore unset
-			listIndex := listIndexPlusOffset - offsetAvoidingUnset
-			if mgr.listUnready[listIndex].ds != nil {
-				ag._index = listIndex
-				if err := mgr.listUnready[listIndex].ds.Setup(&ag); err.IsNotOk() {
-					ag.addErr(ag._index, err)
-					nDone = orderIndex
-					break
-				}
-			}
+		if listIndexPlusOffset <= 0 { // Ignore unset
+			continue
+		}
+		listIndex := listIndexPlusOffset - offsetAvoidingUnset
+		if mgr.listUnready[listIndex].ds == nil {
+			continue
+		}
+		ag._name = mgr.listUnready[listIndex].name
+		ag._index = ii
+		ii++
+		if err := mgr.listUnready[listIndex].ds.Setup(&ag); err.IsNotOk() {
+			ag.addErr(ag._index, ag._name, err)
+			nDone = orderIndex
+			break
 		}
 	}
-	indexedErrors := ag.join()
+	errors := ag.join()
 
-	if len(indexedErrors) == 0 {
+	if len(errors) == 0 {
 		for _, listIndexPlusOffset := range orderedIndexes {
-			if listIndexPlusOffset > 0 { // Ignore unset
-				listIndex := listIndexPlusOffset - offsetAvoidingUnset
-				if mgr.listUnready[listIndex].ds != nil {
-					mgr.listReady = append(mgr.listReady, mgr.listUnready[listIndex])
-				}
+			if listIndexPlusOffset <= 0 { // Ignore unset
+				continue
 			}
+			listIndex := listIndexPlusOffset - offsetAvoidingUnset
+			if mgr.listUnready[listIndex].ds == nil {
+				continue
+			}
+			mgr.listReady = append(mgr.listReady, mgr.listUnready[listIndex])
 		}
 		mgr.listUnready = nil
 		return nil
@@ -199,11 +195,6 @@ func (mgr *dataSrcManager) setupWithOrder(names []string) []DataSrcErr {
 					mgr.listUnready[listIndex].ds.Close()
 				}
 			}
-		}
-		errors := make([]DataSrcErr, len(indexedErrors))
-		for i, idxErr := range indexedErrors {
-			errors[i].Name = mgr.listUnready[idxErr.Index].name
-			errors[i].Err = idxErr.Err
 		}
 		return errors
 	}


### PR DESCRIPTION
## Overview
This PR introduces the `ErrEntry` struct to standardize error handling in scenarios where multiple errors occur during concurrent or batch processing. Previously, the codebase used `IndexedErr`, `DataConnErr`, and `DataSrcErr` for similar purposes. These have been consolidated into `ErrEntry` to provide a consistent and more informative error reporting structure.

## Changes
- **Introduced `ErrEntry` struct**: Now includes `Index` (for task identification) and `Name` (for resource or task labeling) alongside the `Err` value.
- **Refactoring**: 
    - Replaced `IndexedErr` with `ErrEntry` in `AsyncGroup`.
    - Updated `DataConnErr` and `DataSrcErr` references to `ErrEntry`.
    - Updated associated logic in `data-conn.go`, `data-hub.go`, and `data-src.go` to support the new structure.
- **Testing**: Updated unit tests to reflect the structural changes. 
    - *Note: Some assertions in `async-group_test.go` are currently commented out to avoid flaky tests, as goroutine completion order is non-deterministic and cannot be guaranteed by `time.Sleep`.*

## Impact
This change improves code maintainability and provides better traceability when debugging failures in concurrent tasks by including the task name directly in the error entry.