### PR TITLE
fix: fixed findByName to return nil for the name which is specified in the commit order but not added 

### DIFF
--- a/data-conn.go
+++ b/data-conn.go
@@ -122,7 +122,9 @@ func (mgr *dataConnManager) add(cont dataConnContainer) {
 
 func (mgr *dataConnManager) findByName(name string) (*dataConnContainer, bool) {
 	if idx, ok := mgr.indexMap[name]; ok {
-		return &mgr.list[idx], true
+		if mgr.list[idx].conn != nil {
+			return &mgr.list[idx], true
+		}
 	}
 	return nil, false
 }

--- a/data-conn_test.go
+++ b/data-conn_test.go
@@ -334,6 +334,46 @@ func TestDataConn(t *testing.T) {
 		assert.False(t, ok)
 	})
 
+	t.Run("find by name of ordered DataConn", func(t *testing.T) {
+		logger := list.New()
+
+		manager := newDataConnManagerWithCommitOrder([]string{"baz", "qux", "foo"})
+
+		conn1 := NewSyncDataConn(1, logger, Fail_Not)
+		manager.add(dataConnContainer{name: "foo", conn: &conn1})
+
+		conn2 := NewSyncDataConn(2, logger, Fail_Not)
+		manager.add(dataConnContainer{name: "bar", conn: &conn2})
+
+		conn3 := NewSyncDataConn(3, logger, Fail_Not)
+		manager.add(dataConnContainer{name: "baz", conn: &conn3})
+
+		assert.Len(t, manager.indexMap, 4)
+		assert.Equal(t, manager.indexMap["foo"], 2)
+		assert.Equal(t, manager.list[2].conn, &conn1)
+		assert.Equal(t, manager.indexMap["bar"], 3)
+		assert.Equal(t, manager.list[3].conn, &conn2)
+		assert.Equal(t, manager.indexMap["qux"], 1)
+		assert.Nil(t, manager.list[1].conn)
+		assert.Equal(t, manager.indexMap["baz"], 0)
+		assert.Equal(t, manager.list[0].conn, &conn3)
+
+		cont, ok := manager.findByName("foo")
+		assert.True(t, ok)
+		assert.Equal(t, cont.conn, &conn1)
+
+		cont, ok = manager.findByName("bar")
+		assert.True(t, ok)
+		assert.Equal(t, cont.conn, &conn2)
+
+		cont, ok = manager.findByName("baz")
+		assert.True(t, ok)
+		assert.Equal(t, cont.conn, &conn3)
+
+		_, ok = manager.findByName("qux")
+		assert.False(t, ok)
+	})
+
 	t.Run("new failure reports", func(t *testing.T) {
 		logger := list.New()
 


### PR DESCRIPTION
This PR fixes a bug that `findByName` method returned non-nil even if the name is specified in the commit order of `newDataConnManagerWithCommitOrder` but the `dataConnContainer` which is named it is not added.