### PR TITLE
update: added FromDataConnType field to FailToCastDataConn

### DIFF
--- a/data-hub.go
+++ b/data-hub.go
@@ -51,8 +51,9 @@ type /* error reasons */ (
 	// successfully retrieved, but could not be type-cast to the specific implementation expected by
 	// the caller.
 	FailToCastDataConn struct {
-		Name           string
-		ToDataConnType string
+		Name             string
+		FromDataConnType string
+		ToDataConnType   string
 	}
 
 	// FailToCastDataHub represents an error reason indicating that the provided DataHub instance
@@ -309,7 +310,8 @@ func GetDataConn[C DataConn](data any, name string) (C, errs.Err) {
 
 	c, ok := dc.(C)
 	if !ok {
-		return *new(C), errs.New(FailToCastDataConn{Name: name, ToDataConnType: toType})
+		return *new(C), errs.New(FailToCastDataConn{
+			Name: name, FromDataConnType: typeNameOf(dc), ToDataConnType: toType})
 	}
 
 	return c, errs.Ok()

--- a/data-hub_test.go
+++ b/data-hub_test.go
@@ -1393,6 +1393,7 @@ func TestDataHub(t *testing.T) {
 				switch rsn := err.Reason().(type) {
 				case FailToCastDataConn:
 					assert.Equal(t, rsn.Name, "bar")
+					assert.Equal(t, rsn.FromDataConnType, "*sabi.MyDataConn")
 					assert.Equal(t, rsn.ToDataConnType, "*sabi.BadDataConn")
 				default:
 					assert.Fail(t, err.Error())


### PR DESCRIPTION
This PR adds the `FromDataConnType` field which holds the data type name inheriting `DataConn` to be cast of `FailToCastDataConn` error struct.