### PR TITLE
update: removed context from DataHub

### DIFF
--- a/data-hub.go
+++ b/data-hub.go
@@ -5,8 +5,6 @@
 package sabi
 
 import (
-	"context"
-
 	"github.com/sttk/errs"
 )
 
@@ -149,10 +147,6 @@ type dataHubImpl struct {
 	dataConnManager     dataConnManager
 	dataConnMap         map[string]dataConnContainer
 	fixed               bool
-
-	origCtx context.Context
-	ctx     context.Context
-	cancel  context.CancelFunc
 }
 
 // NewDataHub creates and initializes a new DataHub instance populated with the currently
@@ -217,7 +211,6 @@ func (hub *dataHubImpl) Close() {
 	if hub.fixed {
 		return
 	}
-	hub.origCtx = nil
 	clear(hub.dataConnMap)
 	hub.dataConnManager.close()
 	clear(hub.dataSrcMap)
@@ -226,10 +219,6 @@ func (hub *dataHubImpl) Close() {
 
 func (hub *dataHubImpl) begin() errs.Err {
 	hub.fixed = true
-
-	if hub.origCtx != nil {
-		hub.ctx, hub.cancel = context.WithCancel(hub.origCtx)
-	}
 
 	errors := hub.localDataSrcManager.setup()
 	if len(errors) > 0 {
@@ -245,27 +234,10 @@ func (hub *dataHubImpl) commitOrRollback(err errs.Err) errs.Err {
 }
 
 func (hub *dataHubImpl) end() {
-	if hub.cancel != nil {
-		cancel := hub.cancel
-		hub.cancel = nil
-		cancel()
-	}
-	if hub.ctx != nil {
-		hub.ctx = nil
-	}
-
 	clear(hub.dataConnMap)
 	hub.dataConnManager.close()
 
 	hub.fixed = false
-}
-
-func (hub *dataHubImpl) Context() context.Context {
-	return hub.ctx
-}
-
-func (hub *dataHubImpl) SetContext(ctx context.Context) {
-	hub.origCtx = ctx
 }
 
 func (hub *dataHubImpl) getDataConn(name string, dataConnType string) (DataConn, errs.Err) {

--- a/data-hub_test.go
+++ b/data-hub_test.go
@@ -2,7 +2,6 @@ package sabi
 
 import (
 	"container/list"
-	"context"
 	"fmt"
 	"testing"
 
@@ -171,9 +170,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("NewDataHubWithCommitOrder", func(t *testing.T) {
@@ -189,9 +185,6 @@ func TestDataHub(t *testing.T) {
 		assert.Len(t, hubImpl.dataConnManager.indexMap, 3)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("Uses and ok", func(t *testing.T) {
@@ -212,9 +205,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		assert.True(t, hub.begin().IsOk())
 
@@ -226,9 +216,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("Uses but already fixed", func(t *testing.T) {
@@ -248,9 +235,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		assert.True(t, hub.begin().IsOk())
 
@@ -262,9 +246,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Uses("bar", NewMyDataSrc(2, Failure_None, logger))
 
@@ -276,9 +257,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("Disuses and ok", func(t *testing.T) {
@@ -299,9 +277,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("foo")
 
@@ -313,9 +288,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("bar")
 
@@ -327,9 +299,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("Disuses and fix", func(t *testing.T) {
@@ -350,9 +319,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("foo")
 
@@ -364,9 +330,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("bar")
 
@@ -378,9 +341,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Uses("foo", NewMyDataSrc(1, Failure_None, logger))
 		hub.Uses("bar", NewMyDataSrc(2, Failure_None, logger))
@@ -395,9 +355,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("foo")
 
@@ -409,9 +366,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("bar")
 
@@ -423,9 +377,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.end()
 
@@ -437,9 +388,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("foo")
 
@@ -451,9 +399,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.Disuses("bar")
 
@@ -465,9 +410,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("begin if empty", func(t *testing.T) {
@@ -485,9 +427,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.True(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 
 		hub.end()
 
@@ -499,9 +438,6 @@ func TestDataHub(t *testing.T) {
 		assert.Empty(t, hubImpl.dataConnManager.indexMap)
 		assert.Empty(t, hubImpl.dataConnMap)
 		assert.False(t, hubImpl.fixed)
-		assert.Nil(t, hubImpl.origCtx)
-		assert.Nil(t, hubImpl.ctx)
-		assert.Nil(t, hubImpl.cancel)
 	})
 
 	t.Run("begin and ok", func(t *testing.T) {
@@ -523,9 +459,6 @@ func TestDataHub(t *testing.T) {
 			assert.Empty(t, hubImpl.dataConnManager.indexMap)
 			assert.Empty(t, hubImpl.dataConnMap)
 			assert.False(t, hubImpl.fixed)
-			assert.Nil(t, hubImpl.origCtx)
-			assert.Nil(t, hubImpl.ctx)
-			assert.Nil(t, hubImpl.cancel)
 
 			assert.True(t, hub.begin().IsOk())
 
@@ -537,9 +470,6 @@ func TestDataHub(t *testing.T) {
 			assert.Empty(t, hubImpl.dataConnManager.indexMap)
 			assert.Empty(t, hubImpl.dataConnMap)
 			assert.True(t, hubImpl.fixed)
-			assert.Nil(t, hubImpl.origCtx)
-			assert.Nil(t, hubImpl.ctx)
-			assert.Nil(t, hubImpl.cancel)
 
 			hub.end()
 
@@ -551,9 +481,6 @@ func TestDataHub(t *testing.T) {
 			assert.Empty(t, hubImpl.dataConnManager.indexMap)
 			assert.Empty(t, hubImpl.dataConnMap)
 			assert.False(t, hubImpl.fixed)
-			assert.Nil(t, hubImpl.origCtx)
-			assert.Nil(t, hubImpl.ctx)
-			assert.Nil(t, hubImpl.cancel)
 		}()
 
 		log := logger.Front()
@@ -588,9 +515,6 @@ func TestDataHub(t *testing.T) {
 			assert.Empty(t, hubImpl.dataConnManager.indexMap)
 			assert.Empty(t, hubImpl.dataConnMap)
 			assert.False(t, hubImpl.fixed)
-			assert.Nil(t, hubImpl.origCtx)
-			assert.Nil(t, hubImpl.ctx)
-			assert.Nil(t, hubImpl.cancel)
 
 			err := hub.begin()
 			defer hub.end()
@@ -1445,46 +1369,6 @@ func TestDataHub(t *testing.T) {
 		assert.Equal(t, log.Value, "MyDataSrc#Close 1")
 		log = log.Next()
 		assert.Nil(t, log)
-	})
-
-	t.Run("use context.Context", func(t *testing.T) {
-		logger := list.New()
-
-		hub := NewDataHub()
-		defer hub.Close()
-
-		hub.Uses("foo", NewMyDataSrc(1, Failure_None, logger))
-
-		err := Run(hub, func(data DataAcc) errs.Err {
-			logger.PushBack("execute logic")
-			assert.Nil(t, data.Context())
-			return errs.Ok()
-		})
-		assert.True(t, err.IsOk())
-
-		err = Txn(hub, func(data DataAcc) errs.Err {
-			logger.PushBack("execute logic")
-			assert.Nil(t, data.Context())
-			return errs.Ok()
-		})
-		assert.True(t, err.IsOk())
-
-		ctx := context.Background()
-		hub.(*dataHubImpl).SetContext(ctx)
-
-		err = Run(hub, func(data DataAcc) errs.Err {
-			logger.PushBack("execute logic")
-			assert.NotNil(t, data.Context())
-			return errs.Ok()
-		})
-		assert.True(t, err.IsOk())
-
-		err = Txn(hub, func(data DataAcc) errs.Err {
-			logger.PushBack("execute logic")
-			assert.NotNil(t, data.Context())
-			return errs.Ok()
-		})
-		assert.True(t, err.IsOk())
 	})
 }
 


### PR DESCRIPTION
This PR removes `Context` from `DataHub`.

The original intention was to allow a `Context` to be set on `DataHub` so that it could be used within `DataAcc` when needed. However, `Context` can instead be accessed in `DataAcc` through `DataSrc`/`DataConn`, just like other data.

If the required context is the HTTP request context, it can be obtained directly from the HTTP request. Otherwise, a map-based `DataSrc`/`DataConn` can be used.
